### PR TITLE
redesign launcher UI with dark theme and modern layout

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,15 +5,39 @@
 #include <chrono>
 #include <commctrl.h>
 #include <shellapi.h>
+#include <dwmapi.h>
+#include <uxtheme.h>
 
 #pragma comment(lib, "comctl32.lib")
 #pragma comment(lib, "shell32.lib")
+#pragma comment(lib, "dwmapi.lib")
+#pragma comment(lib, "uxtheme.lib")
 
 namespace fs = std::filesystem;
 
-HWND g_hWnd = NULL;
-HWND g_hStaticText = NULL;
-HWND g_hProgressBar = NULL;
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+
+// ── Color palette (dark theme) ────────────────────────────────────────────
+static const COLORREF CLR_BG      = RGB(18,  18,  30);   // deep navy
+static const COLORREF CLR_ACCENT  = RGB(88,  166, 255);  // sky blue
+static const COLORREF CLR_TITLE   = RGB(235, 235, 255);  // near-white
+static const COLORREF CLR_STATUS  = RGB(120, 128, 160);  // muted gray-blue
+static const COLORREF CLR_DIVIDER = RGB(42,  44,  68);   // subtle separator
+static const COLORREF CLR_PB_BG   = RGB(38,  40,  62);   // progress track
+
+// ── Globals ───────────────────────────────────────────────────────────────
+HWND   g_hWnd         = NULL;
+HWND   g_hTitle       = NULL;
+HWND   g_hBadge       = NULL;
+HWND   g_hStaticText  = NULL;
+HWND   g_hProgressBar = NULL;
+HBRUSH g_hBgBrush     = NULL;
+HFONT  g_hTitleFont   = NULL;
+HFONT  g_hBadgeFont   = NULL;
+HFONT  g_hStatusFont  = NULL;
+
 const wchar_t* g_windowClass = L"NokiLauncherWindow";
 
 void ShowErrorMessage(const std::wstring& message);
@@ -32,9 +56,8 @@ bool IsRunningAsAdmin() {
     SID_IDENTIFIER_AUTHORITY ntAuthority = SECURITY_NT_AUTHORITY;
     if (AllocateAndInitializeSid(&ntAuthority, 2, SECURITY_BUILTIN_DOMAIN_RID,
         DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, &adminGroup)) {
-        if (!CheckTokenMembership(NULL, adminGroup, &isAdmin)) {
+        if (!CheckTokenMembership(NULL, adminGroup, &isAdmin))
             isAdmin = FALSE;
-        }
         FreeSid(adminGroup);
     }
 
@@ -48,8 +71,8 @@ bool RestartAsAdmin() {
     SHELLEXECUTEINFOW sei = { sizeof(sei) };
     sei.lpVerb = L"runas";
     sei.lpFile = currentPath;
-    sei.hwnd = NULL;
-    sei.nShow = SW_NORMAL;
+    sei.hwnd   = NULL;
+    sei.nShow  = SW_NORMAL;
 
     return ShellExecuteExW(&sei) == TRUE;
 }
@@ -59,26 +82,23 @@ void ShowErrorMessage(const std::wstring& message) {
 }
 
 void UpdateProgress(int percentage, const std::wstring& message) {
-    if (g_hStaticText) {
+    if (g_hStaticText)
         SetWindowTextW(g_hStaticText, message.c_str());
-    }
-    if (g_hProgressBar) {
+    if (g_hProgressBar)
         SendMessage(g_hProgressBar, PBM_SETPOS, percentage, 0);
-    }
 }
 
 void checkAndLaunch(HWND hwnd) {
     wchar_t current_path[MAX_PATH];
     GetModuleFileNameW(NULL, current_path, MAX_PATH);
     fs::path current_dir = fs::path(current_path).parent_path();
-
-    fs::path exe_path = current_dir / "dist" / "Noki_HBR_Auto.exe";
+    fs::path exe_path    = current_dir / "dist" / "Noki_HBR_Auto.exe";
 
     try {
         UpdateProgress(10, L"正在初始化...");
         std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
-        UpdateProgress(30, L"检查目标文件是否存在...");
+        UpdateProgress(30, L"检查目标文件...");
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
         if (fs::exists(exe_path)) {
@@ -88,121 +108,139 @@ void checkAndLaunch(HWND hwnd) {
             STARTUPINFOW si = { sizeof(si) };
             PROCESS_INFORMATION pi;
 
-            std::wstring exe_path_str = exe_path.wstring();
-            wchar_t* cmd_line = &exe_path_str[0];
+            std::wstring exe_str = exe_path.wstring();
+            wchar_t* cmd_line    = &exe_str[0];
 
-            if (CreateProcessW(
-                NULL,
-                cmd_line,
-                NULL,
-                NULL,
-                FALSE,
-                0,
-                NULL,
-                NULL,
-                &si,
-                &pi
-            )) {
+            if (CreateProcessW(NULL, cmd_line, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
                 CloseHandle(pi.hProcess);
                 CloseHandle(pi.hThread);
 
                 UpdateProgress(100, L"启动成功！");
-                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                std::this_thread::sleep_for(std::chrono::milliseconds(800));
 
                 PostMessage(hwnd, WM_CLOSE, 0, 0);
-            }
-            else {
+            } else {
                 DWORD error = GetLastError();
-                std::wstring error_msg = L"无法启动程序: " + exe_path.wstring() +
-                    L"\n错误代码: " + std::to_wstring(error);
-
-                PostMessage(hwnd, WM_USER + 1, 0, (LPARAM)new std::wstring(error_msg));
+                std::wstring msg = L"无法启动程序: " + exe_path.wstring() +
+                                   L"\n错误代码: " + std::to_wstring(error);
+                PostMessage(hwnd, WM_USER + 1, 0, (LPARAM)new std::wstring(msg));
             }
+        } else {
+            std::wstring msg = L"目标程序不存在:\n" + exe_path.wstring();
+            PostMessage(hwnd, WM_USER + 1, 0, (LPARAM)new std::wstring(msg));
         }
-        else {
-            std::wstring error_msg = L"目标程序不存在:\n" + exe_path.wstring();
-            PostMessage(hwnd, WM_USER + 1, 0, (LPARAM)new std::wstring(error_msg));
-        }
-    }
-    catch (const std::exception& e) {
-        std::string error_str = e.what();
-        std::wstring error_msg = L"发生异常: " + std::wstring(error_str.begin(), error_str.end());
-        PostMessage(hwnd, WM_USER + 1, 0, (LPARAM)new std::wstring(error_msg));
+    } catch (const std::exception& e) {
+        std::string s = e.what();
+        std::wstring msg = L"发生异常: " + std::wstring(s.begin(), s.end());
+        PostMessage(hwnd, WM_USER + 1, 0, (LPARAM)new std::wstring(msg));
     }
 }
 
 void HandleErrorMessage(HWND hwnd, LPARAM lParam) {
-    std::wstring* error_msg = (std::wstring*)lParam;
-    ShowErrorMessage(*error_msg);
-    delete error_msg; 
-
+    std::wstring* msg = (std::wstring*)lParam;
+    ShowErrorMessage(*msg);
+    delete msg;
     PostMessage(hwnd, WM_CLOSE, 0, 0);
 }
 
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     switch (uMsg) {
-    case WM_CREATE:
-    {
-        HWND hTitle = CreateWindowW(
-            L"STATIC",
-            L"Noki启动器 (管理员模式)",
-            WS_VISIBLE | WS_CHILD | SS_CENTER,
-            10, 15, 380, 25,
-            hwnd,
-            NULL,
-            (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE),
-            NULL
-        );
 
-    
-        HFONT hTitleFont = CreateFontW(
-            20, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE,
+    case WM_CREATE: {
+        HINSTANCE hInst = (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE);
+
+        // ── Title "Noki 启动器" ───────────────────────────────────────────
+        g_hTitle = CreateWindowW(L"STATIC", L"Noki 启动器",
+            WS_VISIBLE | WS_CHILD | SS_LEFT,
+            24, 20, 300, 34,
+            hwnd, NULL, hInst, NULL);
+        g_hTitleFont = CreateFontW(
+            26, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE,
             DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
-            DEFAULT_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"微软雅黑"
-        );
-        SendMessage(hTitle, WM_SETFONT, (WPARAM)hTitleFont, TRUE);
+            CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"微软雅黑");
+        SendMessage(g_hTitle, WM_SETFONT, (WPARAM)g_hTitleFont, TRUE);
 
+        // ── Badge "管理员模式" (right-aligned, accent color) ─────────────
+        g_hBadge = CreateWindowW(L"STATIC", L"管理员模式",
+            WS_VISIBLE | WS_CHILD | SS_RIGHT,
+            336, 32, 120, 17,
+            hwnd, NULL, hInst, NULL);
+        g_hBadgeFont = CreateFontW(
+            13, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
+            DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+            CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"微软雅黑");
+        SendMessage(g_hBadge, WM_SETFONT, (WPARAM)g_hBadgeFont, TRUE);
 
-        g_hStaticText = CreateWindowW(
-            L"STATIC",
-            L"正在初始化...",
-            WS_VISIBLE | WS_CHILD | SS_CENTER,
-            10, 50, 380, 25,
-            hwnd,
-            NULL,
-            (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE),
-            NULL
-        );
-
-  
-        HFONT hStatusFont = CreateFontW(
+        // ── Status text ──────────────────────────────────────────────────
+        g_hStaticText = CreateWindowW(L"STATIC", L"正在初始化...",
+            WS_VISIBLE | WS_CHILD | SS_LEFT,
+            24, 78, 432, 22,
+            hwnd, NULL, hInst, NULL);
+        g_hStatusFont = CreateFontW(
             14, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
             DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
-            DEFAULT_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"微软雅黑"
-        );
-        SendMessage(g_hStaticText, WM_SETFONT, (WPARAM)hStatusFont, TRUE);
+            CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"微软雅黑");
+        SendMessage(g_hStaticText, WM_SETFONT, (WPARAM)g_hStatusFont, TRUE);
 
- 
-        g_hProgressBar = CreateWindowW(
-            PROGRESS_CLASSW,  
-            NULL,
+        // ── Progress bar (thin, custom colored) ─────────────────────────
+        g_hProgressBar = CreateWindowW(PROGRESS_CLASSW, NULL,
             WS_VISIBLE | WS_CHILD | PBS_SMOOTH,
-            50, 85, 300, 20,
-            hwnd,
-            NULL,
-            (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE),
-            NULL
-        );
-
-
+            24, 112, 432, 8,
+            hwnd, NULL, hInst, NULL);
+        // Disable visual styles so PBM_SETBARCOLOR takes effect
+        SetWindowTheme(g_hProgressBar, L"", L"");
         SendMessage(g_hProgressBar, PBM_SETRANGE, 0, MAKELPARAM(0, 100));
         SendMessage(g_hProgressBar, PBM_SETPOS, 0, 0);
+        SendMessage(g_hProgressBar, PBM_SETBARCOLOR, 0, CLR_ACCENT);
+        SendMessage(g_hProgressBar, PBM_SETBKCOLOR, 0, CLR_PB_BG);
 
         std::thread(checkAndLaunch, hwnd).detach();
+        break;
     }
-    break;
+
+    case WM_PAINT: {
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(hwnd, &ps);
+
+        RECT rcClient;
+        GetClientRect(hwnd, &rcClient);
+
+        // Accent strip at very top (4px)
+        RECT rcStrip = { 0, 0, rcClient.right, 4 };
+        HBRUSH hAccentBrush = CreateSolidBrush(CLR_ACCENT);
+        FillRect(hdc, &rcStrip, hAccentBrush);
+        DeleteObject(hAccentBrush);
+
+        // Thin horizontal divider below title area
+        HPEN hPen    = CreatePen(PS_SOLID, 1, CLR_DIVIDER);
+        HPEN hOldPen = (HPEN)SelectObject(hdc, hPen);
+        MoveToEx(hdc, 24, 64, NULL);
+        LineTo(hdc, rcClient.right - 24, 64);
+        SelectObject(hdc, hOldPen);
+        DeleteObject(hPen);
+
+        EndPaint(hwnd, &ps);
+        break;
+    }
+
+    case WM_CTLCOLORSTATIC: {
+        HDC   hdc   = (HDC)wParam;
+        HWND  hCtrl = (HWND)lParam;
+        SetBkMode(hdc, TRANSPARENT);
+        if (hCtrl == g_hTitle)
+            SetTextColor(hdc, CLR_TITLE);
+        else if (hCtrl == g_hBadge)
+            SetTextColor(hdc, CLR_ACCENT);
+        else
+            SetTextColor(hdc, CLR_STATUS);
+        return (LRESULT)g_hBgBrush;
+    }
 
     case WM_DESTROY:
+        if (g_hBgBrush)    { DeleteObject(g_hBgBrush);    g_hBgBrush    = NULL; }
+        if (g_hTitleFont)  { DeleteObject(g_hTitleFont);  g_hTitleFont  = NULL; }
+        if (g_hBadgeFont)  { DeleteObject(g_hBadgeFont);  g_hBadgeFont  = NULL; }
+        if (g_hStatusFont) { DeleteObject(g_hStatusFont); g_hStatusFont = NULL; }
         PostQuitMessage(0);
         break;
 
@@ -221,56 +259,42 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 }
 
 BOOL RegisterWindowClass(HINSTANCE hInstance) {
-    WNDCLASSW wc = {};
-    wc.lpfnWndProc = WindowProc;
-    wc.hInstance = hInstance;
+    g_hBgBrush = CreateSolidBrush(CLR_BG);
+
+    WNDCLASSW wc     = {};
+    wc.lpfnWndProc   = WindowProc;
+    wc.hInstance     = hInstance;
     wc.lpszClassName = g_windowClass;
-    wc.hIcon = LoadIcon(hInstance, IDI_APPLICATION);
-    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
-    wc.lpszMenuName = NULL;
-    wc.cbClsExtra = 0;
-    wc.cbWndExtra = 0;
-    wc.style = CS_HREDRAW | CS_VREDRAW;
+    wc.hIcon         = LoadIcon(hInstance, IDI_APPLICATION);
+    wc.hCursor       = LoadCursor(NULL, IDC_ARROW);
+    wc.hbrBackground = g_hBgBrush;
+    wc.style         = CS_HREDRAW | CS_VREDRAW;
 
     return RegisterClassW(&wc);
 }
 
 HWND CreateMainWindow(HINSTANCE hInstance) {
-    HWND hwnd = CreateWindowExW(
+    return CreateWindowExW(
         0,
         g_windowClass,
-        L"Noki启动器 (管理员模式)",
+        L"Noki 启动器",
         WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX,
-        CW_USEDEFAULT, CW_USEDEFAULT, 420, 180,
-        NULL,
-        NULL,
-        hInstance,
-        NULL
+        CW_USEDEFAULT, CW_USEDEFAULT, 480, 190,
+        NULL, NULL, hInstance, NULL
     );
-
-    return hwnd;
 }
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
-
     if (!IsRunningAsAdmin()) {
-
-        if (RestartAsAdmin()) {
-            return 0; 
-        }
-        else {
-            ShowErrorMessage(L"需要管理员权限才能运行此程序。\n请右键点击程序，选择'以管理员身份运行'。");
-            return 1;
-        }
+        if (RestartAsAdmin())
+            return 0;
+        ShowErrorMessage(L"需要管理员权限才能运行此程序。\n请右键点击程序，选择"以管理员身份运行"。");
+        return 1;
     }
-  
-    INITCOMMONCONTROLSEX icex;
-    icex.dwSize = sizeof(INITCOMMONCONTROLSEX);
-    icex.dwICC = ICC_PROGRESS_CLASS;
+
+    INITCOMMONCONTROLSEX icex = { sizeof(INITCOMMONCONTROLSEX), ICC_PROGRESS_CLASS };
     InitCommonControlsEx(&icex);
 
- 
     if (!RegisterWindowClass(hInstance)) {
         ShowErrorMessage(L"无法注册窗口类");
         return 1;
@@ -282,6 +306,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
+    // Dark title bar (Windows 10 20H1+)
+    BOOL darkMode = TRUE;
+    DwmSetWindowAttribute(g_hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
+
+    // Center on screen
     RECT rc;
     GetWindowRect(g_hWnd, &rc);
     int x = (GetSystemMetrics(SM_CXSCREEN) - (rc.right - rc.left)) / 2;


### PR DESCRIPTION
- deep navy background (#12121E) with sky-blue accent strip at top
- dark title bar via DwmSetWindowAttribute (Windows 10 20H1+)
- larger 26pt bold title + right-aligned accent-colored "管理员模式" badge
- thin divider line separating title from status area
- progress bar styled via SetWindowTheme + PBM_SETBARCOLOR/PBM_SETBKCOLOR
- CLEARTYPE_QUALITY fonts throughout; proper GDI resource cleanup on destroy

https://claude.ai/code/session_01SRh2N92kbdASkhEqMXK7tZ