### PR TITLE
feat: 为 get_all_device_ports 添加 target_mode 参数，支持按运行模式过滤 ADB 设备

### DIFF
--- a/Emulator ADB operations.py
+++ b/Emulator ADB operations.py
@@ -67,16 +67,38 @@ def close_app(adb_config, package_name):
     subprocess.run(adb_command, shell=True)
 
 
-def get_all_device_ports(adb_path):
+def _is_emulator_port(port):
+    """Check if a port/serial belongs to an emulator"""
+    port_str = str(port).lower()
+    return (
+        'emulator' in port_str
+        or '127.0.0.1' in port_str
+        or 'localhost' in port_str
+        or port_str.startswith('192.168.')
+    )
+
+
+def get_all_device_ports(adb_path, target_mode='all'):
     """
-    Get list of all connected ADB device ports/serial numbers
+    Get list of connected ADB device ports/serial numbers
 
     Args:
         adb_path: Path to adb executable
+        target_mode: Filter mode for returned devices.
+            - 'all': Return all connected devices (legacy behavior).
+            - 'emulator': Return only emulator devices (e.g. MuMu, LDPlayer, etc.).
+            - 'device': Return only physical Android devices.
+            - 'pc': Return empty list; used when running in PC window mode
+                    so that the script does not occupy any ADB connections.
 
     Returns:
         list: Device port/serial numbers in format like ["emulator-5554", "127.0.0.1:16384"]
     """
+    # When running in PC window mode, skip ADB entirely to avoid
+    # occupying ADB connections used by other scripts (e.g. ALAS).
+    if target_mode == 'pc':
+        return []
+
     try:
         # Execute adb devices command
         adb_command = f'"{adb_path}" devices'
@@ -97,6 +119,12 @@ def get_all_device_ports(adb_path):
             parts = line.strip().split('\t')
             if len(parts) >= 2 and parts[1] == 'device':
                 device_list.append(parts[0])
+
+        # Filter by target mode
+        if target_mode == 'emulator':
+            device_list = [d for d in device_list if _is_emulator_port(d)]
+        elif target_mode == 'device':
+            device_list = [d for d in device_list if not _is_emulator_port(d)]
 
         return device_list
 


### PR DESCRIPTION
## 问题描述
当前脚本启动时会默认搜集**所有**可用端口（包括电脑窗口和 ADB），并且对所有 ADB 设备都进行连接/占用。

这导致一个实际问题：当用户选择**电脑窗口模式**运行脚本时，依然会占用电脑上所有的 ADB 连接，导致其他依赖 ADB 的脚本（例如碧蓝航线的 **ALAS**）无法正常工作。

## 改动内容
给 `Emulator ADB operations.py` 中的 `get_all_device_ports()` 函数增加 `target_mode` 参数：

| 参数值 | 行为 |
|--------|------|
| `'all'` | **默认**，保持原有行为，返回所有 ADB 设备 |
| `'emulator'` | 只返回模拟器端口（如 `emulator-5554`、`127.0.0.1:16384` 等） |
| `'device'` | 只返回真机设备 |
| `'pc'` | **返回空列表**，PC 窗口模式下使用，完全不执行 ADB 操作 |

- 新增 `_is_emulator_port()` 辅助函数用于识别模拟器端口
- **向后兼容**：默认参数为 `'all'`，不改动旧代码也能正常运行

## 作者后续需要做的事
只需在主程序（UI 层）根据用户选择的运行模式，传入对应的 `target_mode` 即可：

```python
# 用户选择"电脑窗口"模式
ports = get_all_device_ports(adb_path, target_mode='pc')

# 用户选择"模拟器"模式
ports = get_all_device_ports(adb_path, target_mode='emulator')